### PR TITLE
fix docs and update leptos version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leptos_animation"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Create animated signals in the Leptos framework"
 homepage = "https://github.com/PaulWagener/leptos_animation"
@@ -10,5 +10,5 @@ license = "WTFPL"
 readme = "README.md"
 
 [dependencies]
-leptos = "0.3.1"
+leptos = "0.4.3"
 instant = { version = "0.1.12", features = ["wasm-bindgen"] }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ use leptos_animation::*;
 
 #[component]
 pub fn Counter(cx: Scope) -> impl IntoView {
-    AnimatedContext::provide(cx);
+    AnimationContext::provide(cx);
 
     let (value, set_value) = create_signal(cx, 0.0);
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "example"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-leptos = { version = "0.3.1", features = ["stable"] }
-leptos_router = { version = "0.3.1", features = ["stable", "csr"] }
+leptos = { version = "0.4.3", features = ["nightly"] }
+leptos_router = { version = "0.4.3", features = ["nightly", "csr"] }
 wasm-bindgen = "0.2.87"
 web-sys = { version = "0.3.64", features = ["CanvasRenderingContext2d"] }
 leptos_animation = { path = ".." }
@@ -16,4 +16,3 @@ derive_more = "0.99.17"
 console_error_panic_hook = "0.1.7"
 log = "0.4.19"
 wasm-logger = "0.2.0"
-

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,8 @@
+# Leptos Animation - Example
+
+## Running Locally
+
+```bash
+cargo install trunk
+trunk serve
+```

--- a/example/rust-toolchain.toml
+++ b/example/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
This PR:

- bumps leptos to the latest version
- fixes the main README
- adds a README for the `example` directory
- bumps the package version

Since this is a breaking change due to the leptos version bump, I bumped the minor version from 0.1 to 0.2. Feel free to change that to whatever you see fit 🙂 

The tests passed and I verified that the demo site works locally. Let me know if there's anything else I should do.